### PR TITLE
Use blittable P/Invoke signature.

### DIFF
--- a/DesktopBridge.Helpers/DesktopBridge.Helpers.csproj
+++ b/DesktopBridge.Helpers/DesktopBridge.Helpers.csproj
@@ -10,6 +10,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/microsoft/Windows-AppConsult-Tools-DesktopBridgeHelpers</PackageProjectUrl>
     <PackageTags>msix, appx, windows, .net</PackageTags>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
 </Project>

--- a/DesktopBridge.Helpers/Helpers.cs
+++ b/DesktopBridge.Helpers/Helpers.cs
@@ -1,15 +1,14 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace DesktopBridge
 {
-    public class Helpers
+    public unsafe class Helpers
     {
         const long APPMODEL_ERROR_NO_PACKAGE = 15700L;
 
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        static extern int GetCurrentPackageFullName(ref int packageFullNameLength, StringBuilder packageFullName);
+        [DllImport("kernel32.dll", ExactSpelling = true)]
+        static extern int GetCurrentPackageFullName(uint* packageFullNameLength, char* packageFullName);
 
         public bool IsRunningAsUwp()
         {
@@ -19,13 +18,8 @@ namespace DesktopBridge
             }
             else
             {
-                int length = 0;
-                StringBuilder sb = new StringBuilder(0);
-                int result = GetCurrentPackageFullName(ref length, sb);
-
-                sb = new StringBuilder(length);
-                result = GetCurrentPackageFullName(ref length, sb);
-
+                uint length = 0;
+                int result = GetCurrentPackageFullName(&length, null);
                 return result != APPMODEL_ERROR_NO_PACKAGE;
             }
         }


### PR DESCRIPTION
This PR updates the P/Invoke definition of `GetCurrentPackageFullName` to use blittable parameters, making the code more friendly to ahead-of-time compilation.

The P/Invoke is also called only once; I've locally tested that even if the buffer is not big enough, it will return `APPMODEL_ERROR_NO_PACKAGE` if the app is not running in a container.